### PR TITLE
Optimize Sponge API 7 primary group provider

### DIFF
--- a/sponge/sponge7/build.gradle
+++ b/sponge/sponge7/build.gradle
@@ -21,5 +21,5 @@ repositories {
     }
 }
 dependencies {
-    compileOnly "org.spongepowered:spongeapi:7.0.0-SNAPSHOT"
+    compileOnly "org.spongepowered:spongeapi:7.0.0"
 }

--- a/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java
+++ b/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java
@@ -18,19 +18,15 @@
 package de.codecrafter47.data.sponge.sponge7;
 
 import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.service.context.Contextual;
 import org.spongepowered.api.service.permission.PermissionService;
-import org.spongepowered.api.service.permission.Subject;
-
-import java.util.concurrent.CompletableFuture;
+import org.spongepowered.api.service.permission.SubjectReference;
 
 public class Sponge7 {
     public static String getPrimaryGroup(Player player) {
         return player.getParents().stream()
-                .map(ref -> ref.resolve().join())
-                .filter(subject -> subject.getContainingCollection().getIdentifier().equals(PermissionService.SUBJECTS_GROUP))
+                .filter(ref -> ref.getCollectionIdentifier().equals(PermissionService.SUBJECTS_GROUP))
                 .findFirst()
-                .map(Contextual::getIdentifier)
+                .map(SubjectReference::getSubjectIdentifier)
                 .orElse(null);
     }
 }


### PR DESCRIPTION
This class actually failed to compile on my CI server, but seemed to work fine locally.

```
/var/lib/jenkins/workspace/minecraft-data-api/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java:30: error: cannot find symbol
                .map(ref -> ref.resolve().join())
                               ^
  symbol:   method resolve()
  location: variable ref of type Subject
/var/lib/jenkins/workspace/minecraft-data-api/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java:31: error: cannot find symbol
                .filter(subject -> subject.getContainingCollection().getIdentifier().equals(PermissionService.SUBJECTS_GROUP))
                                          ^
  symbol:   method getContainingCollection()
  location: variable subject of type Object
/var/lib/jenkins/workspace/minecraft-data-api/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java:33: error: method map in class Optional<T> cannot be applied to given types;
                .map(Contextual::getIdentifier)
                ^
  required: Function<? super Object,? extends U>
  found: Contextual[...]ifier
  reason: cannot infer type-variable(s) U
    (argument mismatch; invalid method reference
      method getIdentifier in interface Contextual cannot be applied to given types
        required: no arguments
        found: Object
        reason: actual and formal argument lists differ in length)
  where U,T are type-variables:
    U extends Object declared in method <U>map(Function<? super T,? extends U>)
    T extends Object declared in class Optional
/var/lib/jenkins/workspace/minecraft-data-api/sponge/sponge7/src/main/java/de/codecrafter47/data/sponge/sponge7/Sponge7.java:33: error: invalid method reference
                .map(Contextual::getIdentifier)
                     ^
  non-static method getIdentifier() cannot be referenced from a static context
4 errors
:sponge:sponge7:compileJava FAILED

```

Not sure what's up there, but anyway, when going to fix it, I noticed this provider can be significantly optimised.

The future `#join` call is quite expensive, but also unnecessary, as the reference already contains all the needed data.