### PR TITLE
Update LuckPerms providers to use the latest API version

### DIFF
--- a/bungee/luckperms/build.gradle
+++ b/bungee/luckperms/build.gradle
@@ -15,12 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-repositories {
-    maven {
-        url "https://repo.lucko.me/"
-    }
-}
-
 dependencies {
-    compileOnly group: "me.lucko.luckperms", name: "luckperms-api", version: "3.4"
+    compileOnly group: "me.lucko.luckperms", name: "luckperms-api", version: "4.0"
 }

--- a/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsPrefixProvider.java
+++ b/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsPrefixProvider.java
@@ -35,17 +35,13 @@ public class LuckPermsPrefixProvider implements Function<ProxiedPlayer, String> 
             return null;
         }
 
-        User user = lp.getUserSafe(player.getUniqueId()).orElse(null);
+        User user = lp.getUser(player.getUniqueId());
         if (user == null) {
             return null;
         }
 
         UserData data = user.getCachedData();
-
-        Contexts context = lp.getContextForUser(user).orElse(null);
-        if (context == null) {
-            return null;
-        }
+        Contexts context = lp.getContextManager().getApplicableContexts(player);
 
         return data.getMetaData(context).getPrefix();
     }

--- a/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsPrimaryGroupProvider.java
+++ b/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsPrimaryGroupProvider.java
@@ -33,7 +33,7 @@ public class LuckPermsPrimaryGroupProvider implements Function<ProxiedPlayer, St
             return null;
         }
 
-        User user = lp.getUserSafe(player.getUniqueId()).orElse(null);
+        User user = lp.getUser(player.getUniqueId());
         if (user == null) {
             return null;
         }

--- a/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsSuffixProvider.java
+++ b/bungee/luckperms/src/main/java/de/codecrafter47/data/bungee/luckperms/LuckPermsSuffixProvider.java
@@ -35,17 +35,13 @@ public class LuckPermsSuffixProvider implements Function<ProxiedPlayer, String> 
             return null;
         }
 
-        User user = lp.getUserSafe(player.getUniqueId()).orElse(null);
+        User user = lp.getUser(player.getUniqueId());
         if (user == null) {
             return null;
         }
 
         UserData data = user.getCachedData();
-
-        Contexts context = lp.getContextForUser(user).orElse(null);
-        if (context == null) {
-            return null;
-        }
+        Contexts context = lp.getContextManager().getApplicableContexts(player);
 
         return data.getMetaData(context).getSuffix();
     }


### PR DESCRIPTION
Updates the LP providers to use the latest API version.

No functional change, but makes use of a method to retrieve a `Contexts` instance using the player object (faster), and removes the reliance on my Nexus repository.