### PR TITLE
Update to Nucleus API 2.3.2

### DIFF
--- a/sponge/build.gradle
+++ b/sponge/build.gradle
@@ -18,7 +18,7 @@
 allprojects {
     repositories {
         maven {
-            url "http://repo.spongepowered.org/maven"
+            url "https://repo.spongepowered.org/maven"
         }
     }
     dependencies {

--- a/sponge/nucleus/build.gradle
+++ b/sponge/nucleus/build.gradle
@@ -24,6 +24,6 @@ repositories {
     }
 }
 dependencies {
-    compileOnly "io.github.nucleuspowered:nucleus-api:1.9.3-S7.1"
+    compileOnly "io.github.nucleuspowered:nucleus-api:2.3.2"
     compileOnly "org.spongepowered:spongeapi:7.0.0"
 }


### PR DESCRIPTION
As it turns out, the APIs are syntactically identical. All that has to be done is change the version number and rebuild.

This does drop support for Nucleus 1.x; I don't know if anyone who uses that needs a more modern version of BungeeTabListPlus.

I also switched the Sponge Maven repo to use HTTPS as that seems to be required now.

Fixes CodeCrafter47/BungeeTabListPlus#623.

