### PR TITLE
fix(velocity): assume ping of 0 when ping information is unavailable

### DIFF
--- a/velocity/src/main/java/de/codecrafter47/data/velocity/PlayerDataAccess.java
+++ b/velocity/src/main/java/de/codecrafter47/data/velocity/PlayerDataAccess.java
@@ -37,7 +37,7 @@ public class PlayerDataAccess extends AbstractVelocityDataAccess<Player> {
         super(server, plugin, logger);
 
         addProvider(VelocityData.Velocity_DisplayName, Player::getUsername);
-        addProvider(VelocityData.Velocity_Ping, player -> (int) player.getPing());
+        addProvider(VelocityData.Velocity_Ping, player -> (int) (player.getPing() < 0 ? 0 : player.getPing()));
         addProvider(VelocityData.Velocity_SessionDuration, VelocitySessionDurationProvider.getInstance(server, plugin));
         addProvider(VelocityData.Velocity_Server, player -> {
             ServerConnection serverConnection = player.getCurrentServer().orElse(null);


### PR DESCRIPTION
Velocity `Player::getPing` returns `-1` if ping information is unavailable (such as immediately after joining): https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/proxy/Player.html#getPing()

Though the current implementation is technically correct, it produces unexpected behaviour in plugins such as BungeeTabListPlus where a player's ping indicator has a big red X through it when first joining, which varies from both vanilla (where ping is `0` before calculated) and [bungeecord](https://github.com/SpigotMC/BungeeCord/blob/master/proxy/src/main/java/net/md_5/bungee/UserConnection.java#L98) (where it for some reason is `100`). Retuning a ping of 0 instead will mirror behaviour on other distributions.